### PR TITLE
III-3399 Don't set age range from to `null` if it's 0 

### DIFF
--- a/src/Serializer/ValueObject/Audience/AgeRangeDenormalizer.php
+++ b/src/Serializer/ValueObject/Audience/AgeRangeDenormalizer.php
@@ -25,8 +25,8 @@ class AgeRangeDenormalizer implements DenormalizerInterface
         $from = $parts[1];
         $to = $parts[2];
 
-        $from = empty($from) ? null : new Age(intval($from));
-        $to = empty($to) ? null : new Age(intval($to));
+        $from = empty($from) ? new Age(0) : new Age((int) $from);
+        $to = empty($to) ? null : new Age((int) $to);
 
         return new AgeRange($from, $to);
     }

--- a/src/ValueObject/Audience/AgeRange.php
+++ b/src/ValueObject/Audience/AgeRange.php
@@ -20,6 +20,8 @@ class AgeRange
      */
     public function __construct(Age $from = null, Age $to = null)
     {
+        $from = $from ?: new Age(0);
+
         if ($from && $to && $from->gt($to)) {
             throw new \InvalidArgumentException('"From" age should not be greater than the "to" age.');
         }
@@ -29,7 +31,7 @@ class AgeRange
     }
 
     /**
-     * @return Age|null
+     * @return Age
      */
     public function getFrom()
     {

--- a/tests/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Serializer/Event/EventDenormalizerTest.php
@@ -589,6 +589,52 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
+    public function it_should_denormalize_event_data_with_typical_age_range_starting_without_number()
+    {
+        $eventData = [
+            '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
+            '@type' => 'Event',
+            '@context' => '/contexts/event',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Titel voorbeeld',
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.be/place/dbe91250-4e4b-495c-b692-3da9563b0d52',
+            ],
+            'calendarType' => 'permanent',
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.1',
+                ],
+            ],
+            'typicalAgeRange' => '-12',
+        ];
+
+        $expected = (new ImmutableEvent(
+            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
+            new Language('nl'),
+            new TranslatedTitle(
+                new Language('nl'),
+                new Title('Titel voorbeeld')
+            ),
+            new PermanentCalendar(new OpeningHours()),
+            PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
+            new Categories(
+                new Category(
+                    new CategoryID('0.50.1.0.1')
+                )
+            )
+        ))->withAgeRange(new AgeRange(new Age(0), new Age(12)));
+
+        $actual = $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_should_denormalize_event_data_with_optional_properties()
     {
         $eventData = [

--- a/tests/ValueObject/Audience/AgeRangeTest.php
+++ b/tests/ValueObject/Audience/AgeRangeTest.php
@@ -53,7 +53,7 @@ class AgeRangeTest extends TestCase
         $to = new Age(10);
         $range = AgeRange::to($to);
 
-        $this->assertNull($range->getFrom());
+        $this->assertEquals(new Age(0), $range->getFrom());
         $this->assertEquals($to, $range->getTo());
     }
 
@@ -89,7 +89,7 @@ class AgeRangeTest extends TestCase
     {
         $range = AgeRange::any();
 
-        $this->assertNull($range->getFrom());
+        $this->assertEquals(new Age(0), $range->getFrom());
         $this->assertNull($range->getTo());
     }
 }


### PR DESCRIPTION
### Fixed

- Age ranges can no longer have a `null` as `from`. It will now default to `0`.

---

Ticket: https://jira.uitdatabank.be/browse/III-3399

Note: This will require a `composer up cultuurnet/udb3-models` in `udb3-silex` after merging it.

Related PR: https://github.com/cultuurnet/udb3-php/pull/470