### PR TITLE
III-3570 - Introduce concept of SubEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /build
 composer.lock
+phpunit.xml

--- a/src/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
+++ b/src/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
@@ -17,7 +17,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Time;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PeriodicCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\TranslatedStatusReason;
 use Symfony\Component\Serializer\Exception\UnsupportedException;
@@ -57,7 +57,7 @@ class CalendarDenormalizer implements DenormalizerInterface
                 if (isset($data['subEvent'][0])) {
                     $subEvent = $this->denormalizeSubEvent($data['subEvent'][0]);
                 }
-                $calendar = new SingleDateRangeCalendar($subEvent);
+                $calendar = new SingleSubEventCalendar($subEvent);
                 break;
 
             case 'multiple':

--- a/src/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
+++ b/src/Serializer/ValueObject/Calendar/CalendarDenormalizer.php
@@ -7,7 +7,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvents;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleDateRangesCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleSubEventsCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Day;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Days;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
@@ -63,7 +63,7 @@ class CalendarDenormalizer implements DenormalizerInterface
             case 'multiple':
                 $subEvents = array_map([$this, 'denormalizeSubEvent'], $data['subEvent']);
                 $subEvents = new SubEvents(...$subEvents);
-                $calendar = new MultipleDateRangesCalendar($subEvents);
+                $calendar = new MultipleSubEventsCalendar($subEvents);
                 break;
 
             case 'periodic':

--- a/src/Validation/Offer/OfferValidator.php
+++ b/src/Validation/Offer/OfferValidator.php
@@ -7,7 +7,7 @@ use CultuurNet\UDB3\Model\Validation\ValueObject\Audience\AgeRangeValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\MultipleDateRangeCalendarValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\PeriodicCalendarValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\PermanentCalendarValidator;
-use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\SingleDateRangeCalendarValidator;
+use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\SingleSubEventCalendarValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\ConfigurableEnumValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Contact\BookingInfoValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Contact\ContactPointValidator;
@@ -82,8 +82,8 @@ abstract class OfferValidator extends Validator
         $allowedTypes = $this->getAllowedCalendarTypes();
 
         $availableRules = [
-            'single' => new SingleDateRangeCalendarValidator(),
-            'multiple' => new MultipleDateRangeCalendarValidator(),
+            'single' => new SingleSubEventCalendarValidator(),
+            'multiple' => new MultipleSubEventsCalendarValidator(),
             'periodic' => new PeriodicCalendarValidator(),
             'permanent' => new PermanentCalendarValidator(),
         ];

--- a/src/Validation/Offer/OfferValidator.php
+++ b/src/Validation/Offer/OfferValidator.php
@@ -4,7 +4,7 @@ namespace CultuurNet\UDB3\Model\Validation\Offer;
 
 use CultuurNet\UDB3\Model\Validation\Organizer\OrganizerReferenceValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Audience\AgeRangeValidator;
-use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\MultipleDateRangeCalendarValidator;
+use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\MultipleSubEventsCalendarValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\PeriodicCalendarValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\PermanentCalendarValidator;
 use CultuurNet\UDB3\Model\Validation\ValueObject\Calendar\SingleSubEventCalendarValidator;

--- a/src/Validation/ValueObject/Calendar/MultipleSubEventsCalendarValidator.php
+++ b/src/Validation/ValueObject/Calendar/MultipleSubEventsCalendarValidator.php
@@ -11,7 +11,7 @@ use Respect\Validation\Rules\KeyValue;
 use Respect\Validation\Rules\When;
 use Respect\Validation\Validator;
 
-class MultipleDateRangeCalendarValidator extends Validator
+class MultipleSubEventsCalendarValidator extends Validator
 {
     public function __construct()
     {

--- a/src/Validation/ValueObject/Calendar/SingleSubEventCalendarValidator.php
+++ b/src/Validation/ValueObject/Calendar/SingleSubEventCalendarValidator.php
@@ -13,7 +13,7 @@ use Respect\Validation\Rules\Length;
 use Respect\Validation\Rules\When;
 use Respect\Validation\Validator;
 
-class SingleDateRangeCalendarValidator extends Validator
+class SingleSubEventCalendarValidator extends Validator
 {
     public function __construct()
     {

--- a/src/ValueObject/Calendar/Calendar.php
+++ b/src/ValueObject/Calendar/Calendar.php
@@ -4,8 +4,5 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 interface Calendar
 {
-    /**
-     * @return CalendarType
-     */
-    public function getType();
+    public function getType(): CalendarType;
 }

--- a/src/ValueObject/Calendar/CalendarType.php
+++ b/src/ValueObject/Calendar/CalendarType.php
@@ -15,7 +15,7 @@ class CalendarType extends Enum
     /**
      * @inheritdoc
      */
-    public static function getAllowedValues()
+    public static function getAllowedValues(): array
     {
         return [
             'single',

--- a/src/ValueObject/Calendar/CalendarWithDateRange.php
+++ b/src/ValueObject/Calendar/CalendarWithDateRange.php
@@ -4,13 +4,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 interface CalendarWithDateRange extends Calendar
 {
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getStartDate();
+    public function getStartDate(): \DateTimeImmutable;
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getEndDate();
+    public function getEndDate(): \DateTimeImmutable;
 }

--- a/src/ValueObject/Calendar/CalendarWithOpeningHours.php
+++ b/src/ValueObject/Calendar/CalendarWithOpeningHours.php
@@ -6,8 +6,5 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 
 interface CalendarWithOpeningHours extends Calendar
 {
-    /**
-     * @return OpeningHours
-     */
-    public function getOpeningHours();
+    public function getOpeningHours(): OpeningHours;
 }

--- a/src/ValueObject/Calendar/CalendarWithSubEvents.php
+++ b/src/ValueObject/Calendar/CalendarWithSubEvents.php
@@ -4,8 +4,5 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 interface CalendarWithSubEvents
 {
-    /**
-     * @return DateRanges
-     */
-    public function getSubEvents();
+    public function getSubEvents(): SubEvents;
 }

--- a/src/ValueObject/Calendar/DateRange.php
+++ b/src/ValueObject/Calendar/DateRange.php
@@ -7,18 +7,6 @@ use CultuurNet\UDB3\Model\ValueObject\DateTimeImmutableRange;
 class DateRange extends DateTimeImmutableRange
 {
     /**
-     * @var Status
-     */
-    private $status;
-
-    public function __construct(\DateTimeImmutable $from, \DateTimeImmutable $to, ?Status $status = null)
-    {
-        // Override the constructor to make both from and to required.
-        parent::__construct($from, $to);
-        $this->status = $status ?? new Status(StatusType::Available());
-    }
-
-    /**
      * @param DateRange $dateRange
      * @return int
      *   Negative if this date range is less than the given date range.
@@ -44,10 +32,5 @@ class DateRange extends DateTimeImmutableRange
         }
 
         return 0;
-    }
-
-    public function getStatus(): Status
-    {
-        return $this->status;
     }
 }

--- a/src/ValueObject/Calendar/MultipleDateRangesCalendar.php
+++ b/src/ValueObject/Calendar/MultipleDateRangesCalendar.php
@@ -5,14 +5,14 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 class MultipleDateRangesCalendar implements CalendarWithDateRange, CalendarWithSubEvents
 {
     /**
-     * @var DateRanges
+     * @var SubEvents
      */
     private $dateRanges;
 
     /**
-     * @param DateRanges $dateRanges
+     * @param SubEvents $dateRanges
      */
-    public function __construct(DateRanges $dateRanges)
+    public function __construct(SubEvents $dateRanges)
     {
         if ($dateRanges->getLength() < 2) {
             throw new \InvalidArgumentException('Multiple date ranges calendar requires at least 2 date ranges.');
@@ -46,7 +46,7 @@ class MultipleDateRangesCalendar implements CalendarWithDateRange, CalendarWithS
     }
 
     /**
-     * @return DateRanges
+     * @return SubEvents
      */
     public function getSubEvents()
     {

--- a/src/ValueObject/Calendar/MultipleDateRangesCalendar.php
+++ b/src/ValueObject/Calendar/MultipleDateRangesCalendar.php
@@ -45,10 +45,7 @@ class MultipleDateRangesCalendar implements CalendarWithDateRange, CalendarWithS
         return $this->dateRanges->getEndDate();
     }
 
-    /**
-     * @return SubEvents
-     */
-    public function getSubEvents()
+    public function getSubEvents(): SubEvents
     {
         return $this->dateRanges;
     }

--- a/src/ValueObject/Calendar/MultipleSubEventsCalendar.php
+++ b/src/ValueObject/Calendar/MultipleSubEventsCalendar.php
@@ -2,7 +2,7 @@
 
 namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
-class MultipleDateRangesCalendar implements CalendarWithDateRange, CalendarWithSubEvents
+class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSubEvents
 {
     /**
      * @var SubEvents

--- a/src/ValueObject/Calendar/MultipleSubEventsCalendar.php
+++ b/src/ValueObject/Calendar/MultipleSubEventsCalendar.php
@@ -9,9 +9,6 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
      */
     private $dateRanges;
 
-    /**
-     * @param SubEvents $dateRanges
-     */
     public function __construct(SubEvents $dateRanges)
     {
         if ($dateRanges->getLength() < 2) {
@@ -21,26 +18,17 @@ class MultipleSubEventsCalendar implements CalendarWithDateRange, CalendarWithSu
         $this->dateRanges = $dateRanges;
     }
 
-    /**
-     * @return CalendarType
-     */
-    public function getType()
+    public function getType(): CalendarType
     {
         return CalendarType::multiple();
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getStartDate()
+    public function getStartDate(): \DateTimeImmutable
     {
         return $this->dateRanges->getStartDate();
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getEndDate()
+    public function getEndDate(): \DateTimeImmutable
     {
         return $this->dateRanges->getEndDate();
     }

--- a/src/ValueObject/Calendar/PeriodicCalendar.php
+++ b/src/ValueObject/Calendar/PeriodicCalendar.php
@@ -16,10 +16,6 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
      */
     private $openingHours;
 
-    /**
-     * @param DateRange $dateRange
-     * @param OpeningHours $openingHours
-     */
     public function __construct(
         DateRange $dateRange,
         OpeningHours $openingHours
@@ -28,34 +24,22 @@ class PeriodicCalendar implements CalendarWithDateRange, CalendarWithOpeningHour
         $this->openingHours = $openingHours;
     }
 
-    /**
-     * @return CalendarType
-     */
-    public function getType()
+    public function getType(): CalendarType
     {
         return CalendarType::periodic();
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getStartDate()
+    public function getStartDate(): \DateTimeImmutable
     {
         return $this->dateRange->getFrom();
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getEndDate()
+    public function getEndDate(): \DateTimeImmutable
     {
         return $this->dateRange->getTo();
     }
 
-    /**
-     * @return OpeningHours
-     */
-    public function getOpeningHours()
+    public function getOpeningHours(): OpeningHours
     {
         return $this->openingHours;
     }

--- a/src/ValueObject/Calendar/PermanentCalendar.php
+++ b/src/ValueObject/Calendar/PermanentCalendar.php
@@ -11,26 +11,17 @@ class PermanentCalendar implements CalendarWithOpeningHours
      */
     private $openingHours;
 
-    /**
-     * @param OpeningHours $openingHours
-     */
     public function __construct(OpeningHours $openingHours)
     {
         $this->openingHours = $openingHours;
     }
 
-    /**
-     * @return CalendarType
-     */
-    public function getType()
+    public function getType(): CalendarType
     {
         return CalendarType::permanent();
     }
 
-    /**
-     * @return OpeningHours
-     */
-    public function getOpeningHours()
+    public function getOpeningHours(): OpeningHours
     {
         return $this->openingHours;
     }

--- a/src/ValueObject/Calendar/SingleDateRangeCalendar.php
+++ b/src/ValueObject/Calendar/SingleDateRangeCalendar.php
@@ -38,10 +38,7 @@ class SingleDateRangeCalendar implements CalendarWithDateRange, CalendarWithSubE
         return $this->subEvent->getDateRange()->getTo();
     }
 
-    /**
-     * @return SubEvents
-     */
-    public function getSubEvents()
+    public function getSubEvents(): SubEvents
     {
         return new SubEvents($this->subEvent);
     }

--- a/src/ValueObject/Calendar/SingleDateRangeCalendar.php
+++ b/src/ValueObject/Calendar/SingleDateRangeCalendar.php
@@ -5,16 +5,13 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 class SingleDateRangeCalendar implements CalendarWithDateRange, CalendarWithSubEvents
 {
     /**
-     * @var DateRange
+     * @var SubEvent
      */
-    private $dateRange;
+    private $subEvent;
 
-    /**
-     * @param DateRange $dateRange
-     */
-    public function __construct(DateRange $dateRange)
+    public function __construct(SubEvent $subEvent)
     {
-        $this->dateRange = $dateRange;
+        $this->subEvent = $subEvent;
     }
 
     /**
@@ -30,7 +27,7 @@ class SingleDateRangeCalendar implements CalendarWithDateRange, CalendarWithSubE
      */
     public function getStartDate()
     {
-        return $this->dateRange->getFrom();
+        return $this->subEvent->getDateRange()->getFrom();
     }
 
     /**
@@ -38,14 +35,14 @@ class SingleDateRangeCalendar implements CalendarWithDateRange, CalendarWithSubE
      */
     public function getEndDate()
     {
-        return $this->dateRange->getTo();
+        return $this->subEvent->getDateRange()->getTo();
     }
 
     /**
-     * @return DateRanges
+     * @return SubEvents
      */
     public function getSubEvents()
     {
-        return new DateRanges($this->dateRange);
+        return new SubEvents($this->subEvent);
     }
 }

--- a/src/ValueObject/Calendar/SingleSubEventCalendar.php
+++ b/src/ValueObject/Calendar/SingleSubEventCalendar.php
@@ -2,7 +2,7 @@
 
 namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
-class SingleDateRangeCalendar implements CalendarWithDateRange, CalendarWithSubEvents
+class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEvents
 {
     /**
      * @var SubEvent

--- a/src/ValueObject/Calendar/SingleSubEventCalendar.php
+++ b/src/ValueObject/Calendar/SingleSubEventCalendar.php
@@ -14,26 +14,17 @@ class SingleSubEventCalendar implements CalendarWithDateRange, CalendarWithSubEv
         $this->subEvent = $subEvent;
     }
 
-    /**
-     * @return CalendarType
-     */
-    public function getType()
+    public function getType(): CalendarType
     {
         return CalendarType::single();
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getStartDate()
+    public function getStartDate(): \DateTimeImmutable
     {
         return $this->subEvent->getDateRange()->getFrom();
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getEndDate()
+    public function getEndDate(): \DateTimeImmutable
     {
         return $this->subEvent->getDateRange()->getTo();
     }

--- a/src/ValueObject/Calendar/SubEvent.php
+++ b/src/ValueObject/Calendar/SubEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
+
+final class SubEvent
+{
+    /**
+     * @var DateRange
+     */
+    private $dateRange;
+
+    /**
+     * @var Status
+     */
+    private $status;
+
+    public function __construct(DateRange $dateRange, Status $status)
+    {
+        $this->dateRange = $dateRange;
+        $this->status = $status;
+    }
+
+    public function getDateRange(): DateRange
+    {
+        return $this->dateRange;
+    }
+
+    public function getStatus(): Status
+    {
+        return $this->status;
+    }
+}

--- a/src/ValueObject/Calendar/SubEvents.php
+++ b/src/ValueObject/Calendar/SubEvents.php
@@ -5,7 +5,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Collection\Behaviour\IsNotEmpty;
 use CultuurNet\UDB3\Model\ValueObject\Collection\Collection;
 
-class DateRanges extends Collection
+class SubEvents extends Collection
 {
     use IsNotEmpty;
 
@@ -20,24 +20,24 @@ class DateRanges extends Collection
     private $endDate;
 
     /**
-     * @param DateRange[] ...$dateRanges
+     * @param SubEvent ...$subEvents
      */
-    public function __construct(DateRange ...$dateRanges)
+    public function __construct(SubEvent ...$subEvents)
     {
-        $this->guardNotEmpty($dateRanges);
+        $this->guardNotEmpty($subEvents);
 
         usort(
-            $dateRanges,
-            function (DateRange $a, DateRange $b) {
-                return $a->compare($b);
+            $subEvents,
+            function (SubEvent $a, SubEvent $b) {
+                return $a->getDateRange()->compare($b->getDateRange());
             }
         );
 
-        parent::__construct(...$dateRanges);
+        parent::__construct(...$subEvents);
 
-        if (count($dateRanges) > 0) {
-            $this->startDate = $this->getFirst()->getFrom();
-            $this->endDate = $this->getLast()->getTo();
+        if (count($subEvents) > 0) {
+            $this->startDate = $this->getFirst()->getDateRange()->getFrom();
+            $this->endDate = $this->getLast()->getDateRange()->getTo();
         }
     }
 

--- a/tests/Event/ImmutableEventTest.php
+++ b/tests/Event/ImmutableEventTest.php
@@ -8,6 +8,9 @@ use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
 use CultuurNet\UDB3\Model\ValueObject\Geography\CountryCode;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Locality;
@@ -133,9 +136,12 @@ class ImmutableEventTest extends TestCase
     private function getCalendar()
     {
         return new SingleDateRangeCalendar(
-            new DateRange(
-                \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
-                \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
+            new SubEvent(
+                new DateRange(
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
+                ),
+                new Status(StatusType::Available())
             )
         );
     }

--- a/tests/Event/ImmutableEventTest.php
+++ b/tests/Event/ImmutableEventTest.php
@@ -7,7 +7,7 @@ use CultuurNet\UDB3\Model\Place\PlaceReference;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Calendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
@@ -135,7 +135,7 @@ class ImmutableEventTest extends TestCase
      */
     private function getCalendar()
     {
-        return new SingleDateRangeCalendar(
+        return new SingleSubEventCalendar(
             new SubEvent(
                 new DateRange(
                     \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),

--- a/tests/Offer/ImmutableOfferTest.php
+++ b/tests/Offer/ImmutableOfferTest.php
@@ -11,6 +11,9 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingInfo;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Contact\TelephoneNumber;
@@ -588,9 +591,12 @@ class ImmutableOfferTest extends TestCase
     private function getCalendar()
     {
         return new SingleDateRangeCalendar(
-            new DateRange(
-                \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
-                \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
+            new SubEvent(
+                new DateRange(
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
+                ),
+                new Status(StatusType::Available())
             )
         );
     }

--- a/tests/Offer/ImmutableOfferTest.php
+++ b/tests/Offer/ImmutableOfferTest.php
@@ -10,7 +10,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\CalendarWithDateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
@@ -590,7 +590,7 @@ class ImmutableOfferTest extends TestCase
      */
     private function getCalendar()
     {
-        return new SingleDateRangeCalendar(
+        return new SingleSubEventCalendar(
             new SubEvent(
                 new DateRange(
                     \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),

--- a/tests/Place/ImmutablePlaceTest.php
+++ b/tests/Place/ImmutablePlaceTest.php
@@ -60,14 +60,14 @@ class ImmutablePlaceTest extends TestCase
     public function it_should_throw_an_exception_if_an_unsupported_calendar_is_injected()
     {
         $calendar = new SingleSubEventCalendar(
-        new SubEvent(
-            new DateRange(
-                \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
-                \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
-            ),
-            new Status(StatusType::Available())
-        )
-    );
+            new SubEvent(
+                new DateRange(
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
+                ),
+                new Status(StatusType::Available())
+            )
+        );
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Given calendar should have opening hours.');

--- a/tests/Place/ImmutablePlaceTest.php
+++ b/tests/Place/ImmutablePlaceTest.php
@@ -10,6 +10,9 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingInfo;
 use CultuurNet\UDB3\Model\ValueObject\Contact\ContactPoint;
 use CultuurNet\UDB3\Model\ValueObject\Geography\Address;
@@ -57,11 +60,14 @@ class ImmutablePlaceTest extends TestCase
     public function it_should_throw_an_exception_if_an_unsupported_calendar_is_injected()
     {
         $calendar = new SingleDateRangeCalendar(
+        new SubEvent(
             new DateRange(
                 \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),
                 \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018')
-            )
-        );
+            ),
+            new Status(StatusType::Available())
+        )
+    );
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Given calendar should have opening hours.');

--- a/tests/Place/ImmutablePlaceTest.php
+++ b/tests/Place/ImmutablePlaceTest.php
@@ -9,7 +9,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\CalendarWithOpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
@@ -59,7 +59,7 @@ class ImmutablePlaceTest extends TestCase
      */
     public function it_should_throw_an_exception_if_an_unsupported_calendar_is_injected()
     {
-        $calendar = new SingleDateRangeCalendar(
+        $calendar = new SingleSubEventCalendar(
         new SubEvent(
             new DateRange(
                 \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018'),

--- a/tests/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Serializer/Event/EventDenormalizerTest.php
@@ -15,7 +15,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvents;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusReason;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleDateRangesCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\MultipleSubEventsCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Day;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Days;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Hour;
@@ -422,7 +422,7 @@ class EventDenormalizerTest extends TestCase
                 new Language('nl'),
                 new Title('Titel voorbeeld')
             ),
-            new MultipleDateRangesCalendar(
+            new MultipleSubEventsCalendar(
                 new SubEvents(
                     new SubEvent(
                         new DateRange(
@@ -540,7 +540,7 @@ class EventDenormalizerTest extends TestCase
                 new Language('nl'),
                 new Title('Titel voorbeeld')
             ),
-            new MultipleDateRangesCalendar(
+            new MultipleSubEventsCalendar(
                 new SubEvents(
                     new SubEvent(
                         new DateRange(

--- a/tests/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Serializer/Event/EventDenormalizerTest.php
@@ -25,7 +25,7 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Time;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PeriodicCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\TranslatedStatusReason;
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingAvailability;
 use CultuurNet\UDB3\Model\ValueObject\Contact\BookingInfo;
@@ -215,7 +215,7 @@ class EventDenormalizerTest extends TestCase
                 new Language('nl'),
                 new Title('Titel voorbeeld')
             ),
-            new SingleDateRangeCalendar(
+            new SingleSubEventCalendar(
                 new SubEvent(
                     new DateRange(
                         \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
@@ -286,7 +286,7 @@ class EventDenormalizerTest extends TestCase
                 new Language('nl'),
                 new Title('Titel voorbeeld')
             ),
-            new SingleDateRangeCalendar(
+            new SingleSubEventCalendar(
                 new SubEvent(
                     new DateRange(
                         \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
@@ -348,7 +348,7 @@ class EventDenormalizerTest extends TestCase
                 new Language('nl'),
                 new Title('Titel voorbeeld')
             ),
-            new SingleDateRangeCalendar(
+            new SingleSubEventCalendar(
                 new SubEvent(
                     new DateRange(
                         \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),

--- a/tests/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Serializer/Event/EventDenormalizerTest.php
@@ -450,7 +450,7 @@ class EventDenormalizerTest extends TestCase
                         new Status(
                             StatusType::Available()
                         )
-                    ),
+                    )
                 )
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),

--- a/tests/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Serializer/Event/EventDenormalizerTest.php
@@ -10,7 +10,8 @@ use CultuurNet\UDB3\Model\ValueObject\Audience\Age;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AgeRange;
 use CultuurNet\UDB3\Model\ValueObject\Audience\AudienceType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRanges;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvents;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusReason;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
@@ -215,9 +216,11 @@ class EventDenormalizerTest extends TestCase
                 new Title('Titel voorbeeld')
             ),
             new SingleDateRangeCalendar(
-                new DateRange(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00'),
+                new SubEvent(
+                    new DateRange(
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                    ),
                     new Status(
                         StatusType::Available()
                     )
@@ -284,9 +287,11 @@ class EventDenormalizerTest extends TestCase
                 new Title('Titel voorbeeld')
             ),
             new SingleDateRangeCalendar(
-                new DateRange(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00'),
+                new SubEvent(
+                    new DateRange(
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                    ),
                     new Status(
                         StatusType::Unavailable(),
                         (new TranslatedStatusReason(
@@ -344,9 +349,11 @@ class EventDenormalizerTest extends TestCase
                 new Title('Titel voorbeeld')
             ),
             new SingleDateRangeCalendar(
-                new DateRange(
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                    \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00'),
+                new SubEvent(
+                    new DateRange(
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                    ),
                     new Status(
                         StatusType::Available()
                     )
@@ -416,28 +423,34 @@ class EventDenormalizerTest extends TestCase
                 new Title('Titel voorbeeld')
             ),
             new MultipleDateRangesCalendar(
-                new DateRanges(
-                    new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00'),
+                new SubEvents(
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        ),
                         new Status(
                             StatusType::Available()
                         )
                     ),
-                    new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00'),
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                        ),
                         new Status(
                             StatusType::Available()
                         )
                     ),
-                    new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00'),
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                        ),
                         new Status(
                             StatusType::Available()
                         )
-                    )
+                    ),
                 )
             ),
             PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
@@ -528,10 +541,12 @@ class EventDenormalizerTest extends TestCase
                 new Title('Titel voorbeeld')
             ),
             new MultipleDateRangesCalendar(
-                new DateRanges(
-                    new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00'),
+                new SubEvents(
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        ),
                         new Status(
                             StatusType::Unavailable(),
                             (new TranslatedStatusReason(
@@ -541,23 +556,29 @@ class EventDenormalizerTest extends TestCase
                                 ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
                         )
                     ),
-                    new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00'),
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                        ),
                         new Status(
                             StatusType::Available()
                         )
                     ),
-                    new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00'),
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                        ),
                         new Status(
                             StatusType::TemporarilyUnavailable()
                         )
                     ),
-                    new DateRange(
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T13:00:00+01:00'),
-                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00'),
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-10T17:00:00+01:00')
+                        ),
                         new Status(
                             StatusType::Available(),
                             (new TranslatedStatusReason(

--- a/tests/ValueObject/Calendar/DateRangesTest.php
+++ b/tests/ValueObject/Calendar/DateRangesTest.php
@@ -16,7 +16,7 @@ class DateRangesTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Array should not be empty.');
 
-        new DateRanges();
+        new SubEvents();
     }
 
     /**
@@ -44,20 +44,23 @@ class DateRangesTest extends TestCase
             ['2018-07-01T00:00:00+01:00', '2018-08-31T00:00:00+01:00'],
         ];
 
-        $mapToDateRange = function (array $range) {
+        $mapToSubEvents = function (array $range) {
             $from = $range[0];
             $to = $range[1];
 
-            return new DateRange(
-                DateTimeImmutable::createFromFormat(DATE_ATOM, $from),
-                DateTimeImmutable::createFromFormat(DATE_ATOM, $to)
+            return new SubEvent(
+                new DateRange(
+                    DateTimeImmutable::createFromFormat(DATE_ATOM, $from),
+                    DateTimeImmutable::createFromFormat(DATE_ATOM, $to)
+                ),
+                new Status(StatusType::Available())
             );
         };
 
-        $given = array_map($mapToDateRange, $given);
-        $expected = array_map($mapToDateRange, $expected);
+        $given = array_map($mapToSubEvents, $given);
+        $expected = array_map($mapToSubEvents, $expected);
 
-        $ranges = new DateRanges(...$given);
+        $ranges = new SubEvents(...$given);
 
         $this->assertEquals($expected, $ranges->toArray());
         $this->assertEquals(7, $ranges->getLength());

--- a/tests/ValueObject/Calendar/MultipleDateRangesCalendarTest.php
+++ b/tests/ValueObject/Calendar/MultipleDateRangesCalendarTest.php
@@ -9,12 +9,12 @@ class MultipleDateRangesCalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_should_require_at_least_two_date_ranges()
+    public function it_should_require_at_least_two_sub_events()
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018');
-        $dateRanges = new DateRanges(
-            new DateRange($startDate, $endDate)
+        $dateRanges = new SubEvents(
+            new SubEvent(new DateRange($startDate, $endDate), new Status(StatusType::Available()))
         );
 
         $this->expectException(\InvalidArgumentException::class);
@@ -31,14 +31,20 @@ class MultipleDateRangesCalendarTest extends TestCase
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
 
-        $dateRanges = new DateRanges(
-            new DateRange(
-                $startDate,
-                \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
+        $dateRanges = new SubEvents(
+            new SubEvent(
+                new DateRange(
+                    $startDate,
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
+                ),
+                new Status(StatusType::Available())
             ),
-            new DateRange(
-                \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
-                $endDate
+            new SubEvent(
+                new DateRange(
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
+                    $endDate
+                ),
+                new Status(StatusType::Available())
             )
         );
 
@@ -56,14 +62,20 @@ class MultipleDateRangesCalendarTest extends TestCase
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
 
-        $dateRanges = new DateRanges(
-            new DateRange(
-                $startDate,
-                \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
+        $dateRanges = new SubEvents(
+            new SubEvent(
+                new DateRange(
+                    $startDate,
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
+                ),
+                new Status(StatusType::Available())
             ),
-            new DateRange(
-                \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
-                $endDate
+            new SubEvent(
+                new DateRange(
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
+                    $endDate
+                ),
+                new Status(StatusType::Available())
             )
         );
 
@@ -80,14 +92,20 @@ class MultipleDateRangesCalendarTest extends TestCase
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
 
-        $dateRanges = new DateRanges(
-            new DateRange(
-                $startDate,
-                \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
+        $dateRanges = new SubEvents(
+            new SubEvent(
+                new DateRange(
+                    $startDate,
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '11/12/2018')
+                ),
+                new Status(StatusType::Available())
             ),
-            new DateRange(
-                \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
-                $endDate
+            new SubEvent(
+                new DateRange(
+                    \DateTimeImmutable::createFromFormat('d/m/Y', '17/12/2018'),
+                    $endDate
+                ),
+                new Status(StatusType::Available())
             )
         );
 

--- a/tests/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
+++ b/tests/ValueObject/Calendar/MultipleSubEventsCalendarTest.php
@@ -4,7 +4,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 use PHPUnit\Framework\TestCase;
 
-class MultipleDateRangesCalendarTest extends TestCase
+class MultipleSubEventsCalendarTest extends TestCase
 {
     /**
      * @test
@@ -20,7 +20,7 @@ class MultipleDateRangesCalendarTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Multiple date ranges calendar requires at least 2 date ranges.');
 
-        new MultipleDateRangesCalendar($dateRanges);
+        new MultipleSubEventsCalendar($dateRanges);
     }
 
     /**
@@ -48,7 +48,7 @@ class MultipleDateRangesCalendarTest extends TestCase
             )
         );
 
-        $calendar = new MultipleDateRangesCalendar($dateRanges);
+        $calendar = new MultipleSubEventsCalendar($dateRanges);
 
         $this->assertEquals($startDate, $calendar->getStartDate());
         $this->assertEquals($endDate, $calendar->getEndDate());
@@ -79,7 +79,7 @@ class MultipleDateRangesCalendarTest extends TestCase
             )
         );
 
-        $calendar = new MultipleDateRangesCalendar($dateRanges);
+        $calendar = new MultipleSubEventsCalendar($dateRanges);
 
         $this->assertEquals($dateRanges, $calendar->getSubEvents());
     }
@@ -109,7 +109,7 @@ class MultipleDateRangesCalendarTest extends TestCase
             )
         );
 
-        $calendar = new MultipleDateRangesCalendar($dateRanges);
+        $calendar = new MultipleSubEventsCalendar($dateRanges);
 
         $this->assertEquals(CalendarType::multiple(), $calendar->getType());
     }

--- a/tests/ValueObject/Calendar/OpeningHours/HourTest.php
+++ b/tests/ValueObject/Calendar/OpeningHours/HourTest.php
@@ -27,10 +27,10 @@ class HourTest extends TestCase
     {
         return [
             'negative' => [
-                'hour' => -1,
+                -1,
             ],
             'over_twenty_three' => [
-                'hour' => 24,
+                24,
             ],
         ];
     }

--- a/tests/ValueObject/Calendar/OpeningHours/MinuteTest.php
+++ b/tests/ValueObject/Calendar/OpeningHours/MinuteTest.php
@@ -27,10 +27,10 @@ class MinuteTest extends TestCase
     {
         return [
             'negative' => [
-                'hour' => -1,
+                -1,
             ],
             'over_fifty_nine' => [
-                'hour' => 60,
+                60,
             ],
         ];
     }

--- a/tests/ValueObject/Calendar/SingleDateRangeCalendarTest.php
+++ b/tests/ValueObject/Calendar/SingleDateRangeCalendarTest.php
@@ -13,7 +13,12 @@ class SingleDateRangeCalendarTest extends TestCase
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleDateRangeCalendar(new DateRange($startDate, $endDate));
+        $calendar = new SingleDateRangeCalendar(
+            new SubEvent(
+                new DateRange($startDate, $endDate),
+                new Status(StatusType::Available())
+            )
+        );
 
         $this->assertEquals(CalendarType::single(), $calendar->getType());
     }
@@ -25,7 +30,12 @@ class SingleDateRangeCalendarTest extends TestCase
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleDateRangeCalendar(new DateRange($startDate, $endDate));
+        $calendar = new SingleDateRangeCalendar(
+            new SubEvent(
+                new DateRange($startDate, $endDate),
+                new Status(StatusType::Available())
+            )
+        );
 
         $this->assertEquals($startDate, $calendar->getStartDate());
         $this->assertEquals($endDate, $calendar->getEndDate());
@@ -38,10 +48,18 @@ class SingleDateRangeCalendarTest extends TestCase
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleDateRangeCalendar(new DateRange($startDate, $endDate));
+        $calendar = new SingleDateRangeCalendar(
+            new SubEvent(
+                new DateRange($startDate, $endDate),
+                new Status(StatusType::Available())
+            )
+        );
 
-        $expected = new DateRanges(
-            new DateRange($startDate, $endDate)
+        $expected = new SubEvents(
+            new SubEvent(
+                new DateRange($startDate, $endDate),
+                new Status(StatusType::Available())
+            )
         );
 
         $this->assertEquals($expected, $calendar->getSubEvents());

--- a/tests/ValueObject/Calendar/SingleSubEventCalendarTest.php
+++ b/tests/ValueObject/Calendar/SingleSubEventCalendarTest.php
@@ -4,7 +4,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
 
 use PHPUnit\Framework\TestCase;
 
-class SingleDateRangeCalendarTest extends TestCase
+class SingleSubEventCalendarTest extends TestCase
 {
     /**
      * @test
@@ -13,7 +13,7 @@ class SingleDateRangeCalendarTest extends TestCase
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleDateRangeCalendar(
+        $calendar = new SingleSubEventCalendar(
             new SubEvent(
                 new DateRange($startDate, $endDate),
                 new Status(StatusType::Available())
@@ -30,7 +30,7 @@ class SingleDateRangeCalendarTest extends TestCase
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleDateRangeCalendar(
+        $calendar = new SingleSubEventCalendar(
             new SubEvent(
                 new DateRange($startDate, $endDate),
                 new Status(StatusType::Available())
@@ -48,7 +48,7 @@ class SingleDateRangeCalendarTest extends TestCase
     {
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/12/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '18/12/2018');
-        $calendar = new SingleDateRangeCalendar(
+        $calendar = new SingleSubEventCalendar(
             new SubEvent(
                 new DateRange($startDate, $endDate),
                 new Status(StatusType::Available())

--- a/tests/ValueObject/Moderation/AvailableToTest.php
+++ b/tests/ValueObject/Moderation/AvailableToTest.php
@@ -6,6 +6,9 @@ use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
 use PHPUnit\Framework\TestCase;
 
 class AvailableToTest extends TestCase
@@ -29,7 +32,10 @@ class AvailableToTest extends TestCase
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018');
 
         $singleDateRangeCalendar = new SingleDateRangeCalendar(
-            new DateRange($startDate, $endDate)
+            new SubEvent(
+                new DateRange($startDate, $endDate),
+                new Status(StatusType::Available())
+            )
         );
 
         $permanentCalendar = new PermanentCalendar(new OpeningHours());

--- a/tests/ValueObject/Moderation/AvailableToTest.php
+++ b/tests/ValueObject/Moderation/AvailableToTest.php
@@ -5,7 +5,7 @@ namespace CultuurNet\UDB3\Model\ValueObject\Moderation;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\DateRange;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\OpeningHours;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\PermanentCalendar;
-use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleDateRangeCalendar;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\SingleSubEventCalendar;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\Status;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\StatusType;
 use CultuurNet\UDB3\Model\ValueObject\Calendar\SubEvent;
@@ -31,7 +31,7 @@ class AvailableToTest extends TestCase
         $startDate = \DateTimeImmutable::createFromFormat('d/m/Y', '10/01/2018');
         $endDate = \DateTimeImmutable::createFromFormat('d/m/Y', '11/01/2018');
 
-        $singleDateRangeCalendar = new SingleDateRangeCalendar(
+        $singleDateRangeCalendar = new SingleSubEventCalendar(
             new SubEvent(
                 new DateRange($startDate, $endDate),
                 new Status(StatusType::Available())


### PR DESCRIPTION
### Added
- Concept of `SubEvent` and `SubEvents` for calendars
 
### Changed
- PHPUnit.xml is now excluded from git so that it's easier to overwrite locally
 
### Fixed
- Removed array keys in data provider that would be incorrectly viewed as named arguments under PHP 8
 
---
Ticket: https://jira.uitdatabank.be/browse/III-3570
