### PR TITLE
Make DateRange from and to required

### DIFF
--- a/src/ValueObject/Calendar/DateRange.php
+++ b/src/ValueObject/Calendar/DateRange.php
@@ -6,6 +6,12 @@ use CultuurNet\UDB3\Model\ValueObject\DateTimeImmutableRange;
 
 class DateRange extends DateTimeImmutableRange
 {
+    public function __construct(\DateTimeImmutable $from, \DateTimeImmutable $to)
+    {
+        // Override the constructor to make both from and to required.
+        parent::__construct($from, $to);
+    }
+
     /**
      * @param DateRange $dateRange
      * @return int

--- a/tests/ValueObject/Calendar/DateRangeTest.php
+++ b/tests/ValueObject/Calendar/DateRangeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Model\ValueObject\Calendar;
+
+use PHPUnit\Framework\TestCase;
+
+final class DateRangeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_requires_a_start_date(): void
+    {
+        $this->expectException(\TypeError::class);
+        new DateRange(null, new \DateTimeImmutable());
+    }
+
+    /**
+     * @test
+     */
+    public function it_requires_an_end_date(): void
+    {
+        $this->expectException(\TypeError::class);
+        new DateRange(new \DateTimeImmutable(), null);
+    }
+}


### PR DESCRIPTION
### Fixed
 
- Made `$from` and `$to` arguments on `DateRange` required again (as it was in `1.0.0`)

---

See: https://github.com/cultuurnet/udb3-models/pull/14/files#r533278036

The reason they have to be required is because a date range in the context of the calendar info can never be (half)-open. It always requires a start and end.
