### PR TITLE
III-3730 Apply top level status on sub events with no status

### DIFF
--- a/tests/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Serializer/Event/EventDenormalizerTest.php
@@ -747,6 +747,88 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
+    public function it_should_denormalize_event_data_with_single_sub_event_and_apply_status_to_sub_event_with_no_status()
+    {
+        $eventData = [
+            '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
+            '@type' => 'Event',
+            '@context' => '/contexts/event',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Titel voorbeeld',
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.be/place/dbe91250-4e4b-495c-b692-3da9563b0d52',
+            ],
+            'calendarType' => 'single',
+            'status' => [
+                'type' => 'TemporarilyUnavailable',
+                'reason' => [
+                    'nl' => 'Nederlands',
+                    'fr' => 'Frans',
+                ],
+            ],
+            'startDate' => '2018-01-01T13:00:00+01:00',
+            'endDate' => '2018-01-01T17:00:00+01:00',
+            'subEvent' => [
+                [
+                    '@type' => 'Event',
+                    'startDate' => '2018-01-01T13:00:00+01:00',
+                    'endDate' => '2018-01-01T17:00:00+01:00',
+                ],
+            ],
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.1',
+                ]
+            ],
+        ];
+
+        $expected = new ImmutableEvent(
+            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
+            new Language('nl'),
+            new TranslatedTitle(
+                new Language('nl'),
+                new Title('Titel voorbeeld')
+            ),
+            (new SingleSubEventCalendar(
+                new SubEvent(
+                    new DateRange(
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                    ),
+                    new Status(
+                        StatusType::TemporarilyUnavailable(),
+                        (new TranslatedStatusReason(
+                            new Language('nl'),
+                            new StatusReason('Nederlands')
+                        ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
+                    )
+                )
+            ))->withStatus(
+                new Status(
+                    StatusType::TemporarilyUnavailable(),
+                    (new TranslatedStatusReason(
+                        new Language('nl'),
+                        new StatusReason('Nederlands')
+                    ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
+                )
+            ),
+            PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
+            new Categories(
+                new Category(
+                    new CategoryID('0.50.1.0.1')
+                )
+            )
+        );
+
+        $actual = $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+    /**
+     * @test
+     */
     public function it_should_denormalize_event_data_with_a_periodic_calendar_and_no_opening_hours()
     {
         $eventData = [

--- a/tests/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Serializer/Event/EventDenormalizerTest.php
@@ -672,6 +672,81 @@ class EventDenormalizerTest extends TestCase
     /**
      * @test
      */
+    public function it_should_denormalize_event_data_with_single_date_range_and_apply_status_to_sub_event_with_no_status()
+    {
+        $eventData = [
+            '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
+            '@type' => 'Event',
+            '@context' => '/contexts/event',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Titel voorbeeld',
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.be/place/dbe91250-4e4b-495c-b692-3da9563b0d52',
+            ],
+            'calendarType' => 'single',
+            'status' => [
+                'type' => 'TemporarilyUnavailable',
+                'reason' => [
+                    'nl' => 'Nederlands',
+                    'fr' => 'Frans',
+                ],
+            ],
+            'startDate' => '2018-01-01T13:00:00+01:00',
+            'endDate' => '2018-01-01T17:00:00+01:00',
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.1',
+                ]
+            ],
+        ];
+
+        $expected = new ImmutableEvent(
+            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
+            new Language('nl'),
+            new TranslatedTitle(
+                new Language('nl'),
+                new Title('Titel voorbeeld')
+            ),
+            (new SingleSubEventCalendar(
+                new SubEvent(
+                    new DateRange(
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
+                        \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                    ),
+                    new Status(
+                        StatusType::TemporarilyUnavailable(),
+                        (new TranslatedStatusReason(
+                            new Language('nl'),
+                            new StatusReason('Nederlands')
+                        ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
+                    )
+                )
+            ))->withStatus(
+                new Status(
+                    StatusType::TemporarilyUnavailable(),
+                    (new TranslatedStatusReason(
+                        new Language('nl'),
+                        new StatusReason('Nederlands')
+                    ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
+                )
+            ),
+            PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
+            new Categories(
+                new Category(
+                    new CategoryID('0.50.1.0.1')
+                )
+            )
+        );
+
+        $actual = $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+    /**
+     * @test
+     */
     public function it_should_denormalize_event_data_with_a_periodic_calendar_and_no_opening_hours()
     {
         $eventData = [

--- a/tests/Serializer/Event/EventDenormalizerTest.php
+++ b/tests/Serializer/Event/EventDenormalizerTest.php
@@ -744,6 +744,7 @@ class EventDenormalizerTest extends TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
     /**
      * @test
      */
@@ -826,6 +827,118 @@ class EventDenormalizerTest extends TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * @test
+     */
+    public function it_should_denormalize_event_data_with_multiple_date_ranges_and_apply_status_to_sub_events_with_no_status()
+    {
+        $eventData = [
+            '@id' => 'https://io.uitdatabank.be/event/9f34efc7-a528-4ea8-a53e-a183f21abbab',
+            '@type' => 'Event',
+            '@context' => '/contexts/event',
+            'mainLanguage' => 'nl',
+            'name' => [
+                'nl' => 'Titel voorbeeld',
+            ],
+            'location' => [
+                '@id' => 'https://io.uitdatabank.be/place/dbe91250-4e4b-495c-b692-3da9563b0d52',
+            ],
+            'calendarType' => 'multiple',
+            'startDate' => '2018-01-01T13:00:00+01:00',
+            'endDate' => '2018-01-10T17:00:00+01:00',
+            'status' => [
+                'type' => 'TemporarilyUnavailable',
+                'reason' => [
+                    'nl' => 'Nederlands',
+                    'fr' => 'Frans',
+                ],
+            ],
+            'subEvent' => [
+                [
+                    '@type' => 'Event',
+                    'startDate' => '2018-01-01T13:00:00+01:00',
+                    'endDate' => '2018-01-01T17:00:00+01:00',
+                    'status' => [
+                        'type' => 'Unavailable',
+                        'reason' => [
+                            'nl' => 'Nederlandse reden',
+                            'fr' => 'Franse reden',
+                        ],
+                    ],
+                ],
+                [
+                    '@type' => 'Event',
+                    'startDate' => '2018-01-03T13:00:00+01:00',
+                    'endDate' => '2018-01-03T17:00:00+01:00',
+                ],
+            ],
+            'terms' => [
+                [
+                    'id' => '0.50.1.0.1',
+                ]
+            ],
+        ];
+
+        $expected = new ImmutableEvent(
+            new UUID('9f34efc7-a528-4ea8-a53e-a183f21abbab'),
+            new Language('nl'),
+            new TranslatedTitle(
+                new Language('nl'),
+                new Title('Titel voorbeeld')
+            ),
+            (new MultipleSubEventsCalendar(
+                new SubEvents(
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-01T17:00:00+01:00')
+                        ),
+                        new Status(
+                            StatusType::Unavailable(),
+                            (new TranslatedStatusReason(
+                                new Language('nl'),
+                                new StatusReason('Nederlandse reden')
+                            ))
+                                ->withTranslation(new Language('fr'), new StatusReason('Franse reden'))
+                        )
+                    ),
+                    new SubEvent(
+                        new DateRange(
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T13:00:00+01:00'),
+                            \DateTimeImmutable::createFromFormat(\DATE_ATOM, '2018-01-03T17:00:00+01:00')
+                        ),
+                        new Status(
+                            StatusType::TemporarilyUnavailable(),
+                            (new TranslatedStatusReason(
+                                new Language('nl'),
+                                new StatusReason('Nederlands')
+                            ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
+                        )
+                    )
+                )
+            ))->withStatus(
+                new Status(
+                    StatusType::TemporarilyUnavailable(),
+                    (new TranslatedStatusReason(
+                        new Language('nl'),
+                        new StatusReason('Nederlands')
+                    ))->withTranslation(new Language('fr'), new StatusReason('Frans'))
+                )
+            ),
+            PlaceReference::createWithPlaceId(new UUID('dbe91250-4e4b-495c-b692-3da9563b0d52')),
+            new Categories(
+                new Category(
+                    new CategoryID('0.50.1.0.1')
+                )
+            )
+        );
+
+        $actual = $this->denormalizer->denormalize($eventData, ImmutableEvent::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
### Changed
 
- Apply top-level status on sub-events with no status to avoid default available status
 
---
Ticket: https://jira.uitdatabank.be/browse/III-3770
